### PR TITLE
Fixes for PHP 8.2 deprecation warnings

### DIFF
--- a/class/Common/Compatibility/CompatibilityManager.php
+++ b/class/Common/Compatibility/CompatibilityManager.php
@@ -67,6 +67,10 @@ class CompatibilityManager {
 	 * @var MigrationStateManager
 	 */
 	public $migration_state;
+	/**
+	 * @var Util
+	 */
+	public $util;
 
 	public function __construct(
 		Filesystem $filesystem,

--- a/class/Common/Profile/ProfileManager.php
+++ b/class/Common/Profile/ProfileManager.php
@@ -48,11 +48,11 @@ class ProfileManager {
 	/**
 	 * @var array
 	 */
-	private $default_profile;
+	public $default_profile;
 	/**
 	 * @var array
 	 */
-	private $checkbox_options;
+	public $checkbox_options;
 
 	/**
 	 * ProfileManager constructor.

--- a/class/Common/Profile/ProfileManager.php
+++ b/class/Common/Profile/ProfileManager.php
@@ -45,6 +45,14 @@ class ProfileManager {
 	 * @var FormData
 	 */
 	private $form_data;
+	/**
+	 * @var array
+	 */
+	private $default_profile;
+	/**
+	 * @var array
+	 */
+	private $checkbox_options;
 
 	/**
 	 * ProfileManager constructor.

--- a/class/Common/Replace.php
+++ b/class/Common/Replace.php
@@ -601,12 +601,12 @@ class Replace {
 	protected function json_replaces( $prefix )
 	{
 		$default_tables = [
-			"${prefix}posts",
+			"{$prefix}posts",
 		];
 
 		if ( in_array( $this->intent, ['find_replace', 'import'] ) ) {
 			$default_tables = [
-				"_mig_${prefix}posts",
+				"_mig_{$prefix}posts",
 			];
 		}
 

--- a/class/Common/Sql/Table.php
+++ b/class/Common/Sql/Table.php
@@ -43,6 +43,10 @@ class Table {
 	 */
 	public $form_data;
 	/**
+	 * @var array
+	 */
+	public $form_data_arr;
+	/**
 	 * @var
 	 */
 	public $query_template;

--- a/class/Pro/Addon/Addon.php
+++ b/class/Pro/Addon/Addon.php
@@ -38,6 +38,10 @@ class Addon {
 	 * @var $addons
 	 */
 	public $addons;
+	/**
+	 * @var Properties
+	 */
+	public $props;
 
 	public function __construct(
 		Api $api,

--- a/class/Pro/License.php
+++ b/class/Pro/License.php
@@ -54,6 +54,10 @@ class License {
 	 * @var static $static_settings
 	 */
 	private static $static_settings;
+	/**
+	 * @var Download
+	 */
+	private $download;
 
 	public function __construct(
 		Api $api,

--- a/class/Pro/Plugin/ProPluginManager.php
+++ b/class/Pro/Plugin/ProPluginManager.php
@@ -23,7 +23,7 @@ class ProPluginManager extends PluginManagerBase {
 	public $addon;
 	public $api;
 	public $download;
-	public $licence;
+	public $license;
 
 	public function __construct(
 		Settings $settings,

--- a/class/Pro/Plugin/ProPluginManager.php
+++ b/class/Pro/Plugin/ProPluginManager.php
@@ -20,6 +20,11 @@ use DeliciousBrains\WPMDB\Pro\License;
 
 class ProPluginManager extends PluginManagerBase {
 
+	public $addon;
+	public $api;
+	public $download;
+	public $licence;
+
 	public function __construct(
 		Settings $settings,
 		Assets $assets,


### PR DESCRIPTION
Fixes for the following types of warnings in PHP 8.2:

- `Using ${var} in strings is deprecated, use {$var} instead`
- `Creation of dynamic property X is deprecated`